### PR TITLE
ARM: fix warnings about atomic64_read

### DIFF
--- a/arch/arm/include/asm/atomic.h
+++ b/arch/arm/include/asm/atomic.h
@@ -243,7 +243,7 @@ typedef struct {
 
 #define ATOMIC64_INIT(i) { (i) }
 
-static inline u64 atomic64_read(atomic64_t *v)
+static inline u64 atomic64_read(const atomic64_t *v)
 {
 	u64 result;
 


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/b89d607b590397c04b63d94a9e2fca9649917955